### PR TITLE
fix negative handling in arm64

### DIFF
--- a/v8_c_bridge.cpp
+++ b/v8_c_bridge.cpp
@@ -745,7 +745,10 @@ extern "C" {
 				return DupString("Cannot assign to an index beyond the size of an array buffer");
 			}
 			else {
-				((unsigned char*)bufPtr->GetContents().Data())[idx] = new_value_local->ToNumber(ctx).ToLocalChecked()->Value();
+				double doubleValue = new_value_local->ToNumber(ctx).ToLocalChecked()->Value();
+				// JavaScript Uint8Array assignment: (value + 256) % 256 to ensure result is in [0, 255]
+				unsigned char byteValue = static_cast<unsigned char>((static_cast<int>(doubleValue) + 256) % 256);
+				((unsigned char*)bufPtr->GetBackingStore()->Data())[idx] = byteValue;
 			}
 		}
 		else {


### PR DESCRIPTION
#2 
In JavaScript, when you assign a negative value to a Uint8Array, it gets converted using the formula (value + 256) % 256 to ensure the result is in the range [0, 255]. So -55 becomes 201.
The problem is in the V8 C++ implementation. The current code doesn't handle negative values correctly. It should implement the same logic above.